### PR TITLE
ci: lint PR titles with conventional commits

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,21 @@
+name: Lint PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This runs a check to ensure that we're using [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/), which ties in with #2 for release notes generation.

We'll need some repo settings changes:

- enable Squash & merge
- enable Default to PR title for squash merge commits
- add branch protection on main requiring the check “Validate PR title” (job name in the workflow)