### PR TITLE
fix: require version before constants

### DIFF
--- a/lib/openfga.rb
+++ b/lib/openfga.rb
@@ -12,11 +12,11 @@ Generator version: 6.4.0
 =end
 
 # Common files
+require 'openfga/version'
 require 'openfga/constants'
 require 'openfga/api_client'
 require 'openfga/api_error'
 require 'openfga/api_model_base'
-require 'openfga/version'
 require 'openfga/configuration'
 
 require 'openfga/imports'


### PR DESCRIPTION
When the version file was required after the constants file I got the following error: 

```
4.0.1 :003 > OpenFga::Version
(irb):3:in '<main>': uninitialized constant OpenFga::Version (NameError)
```
moving it to be required before the constants file fixes it. 