### PR TITLE
chore: pin version of rake to >= 13.2 < 14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rake', '~> 13.0.1'
+  gem 'rake', '>= 13.2', '< 14'
   gem 'pry'
   gem 'webmock', '~> 3.25.2'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     public_suffix (7.0.2)
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.4.2)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -110,7 +110,7 @@ DEPENDENCIES
   openfga!
   pry
   pry-byebug
-  rake (~> 13.0.1)
+  rake (>= 13.2, < 14)
   rspec (~> 3.6, >= 3.6.0)
   rubocop (~> 1.75.1)
   rubocop-rspec (~> 3.5.0)


### PR DESCRIPTION
This should fix an issue in the release process, which now uses Ruby 4.0.1. In this version, a dependency that rake previously depended on is no longer included by default. This change pushes rake to a version that no longer requires this dependency.

https://github.com/carlastabile/openfga-ruby-sdk/actions/runs/24730513516/job/72343369432