### PR TITLE
chore: remove Ruby version 3.2 from build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4', '4.0.1']
+        ruby-version: ['3.3', '3.4', '4.0.1']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ruby 3.2 is now EOL as of a few weeks ago.

https://endoflife.date/ruby