### PR TITLE
chore: extract gem publishing and allow workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: publish
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref, tag, or SHA to publish from
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref, tag, or SHA to publish from (defaults to the selected branch/tag)
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    environment: release
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          bundler: latest
+          rubygems: latest
+      - name: Update bundler
+        run: gem update bundler
+
+      - uses: rubygems/release-gem@v1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,31 +20,13 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-  push:
+  publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
-    
-    runs-on: ubuntu-latest
-
-    environment: release
-
     permissions:
       contents: write
       id-token: write
-
-    steps:
-      # Set up
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          bundler: latest
-          rubygems: latest
-      - name: Update bundler
-        run: gem update bundler
-
-      # Release
-      - uses: rubygems/release-gem@v1
+    uses: ./.github/workflows/publish.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
This change will allow us to just push the gem to RubyGems in the event that `release-please` completes successfully but the gem publishing step fails. The workflow has been refactored a bit so that the `release-please` workflow can re-use the `publish` workflow (so no duplication of steps), or we can just invoke `publish` manually when necessary.

Ideally `release-please` will just work all the time, but in those rare cases when the gem doesn't go out, we can fix it in `main` then retry the publish.