### PR TITLE
ci: add example integration tests workflow

### DIFF
--- a/.github/workflows/example-tests.yaml
+++ b/.github/workflows/example-tests.yaml
@@ -10,20 +10,24 @@ jobs:
   example-tests:
     runs-on: ubuntu-latest
 
-    services:
-      openfga:
-        image: openfga/openfga:latest
-        ports:
-          - 8080:8080
-        options: >-
-          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8080/healthz || exit 1"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-          --health-start-period 10s
-
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start OpenFGA server
+        run: docker run -d --name openfga -p 8080:8080 openfga/openfga:latest run
+
+      - name: Wait for OpenFGA to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if wget --no-verbose --tries=1 --spider http://localhost:8080/healthz 2>/dev/null; then
+              echo "OpenFGA is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "OpenFGA failed to start"
+          docker logs openfga
+          exit 1
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/example-tests.yaml
+++ b/.github/workflows/example-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Wait for OpenFGA to be ready
         run: |
           for i in $(seq 1 30); do
-            if wget --no-verbose --tries=1 --spider http://localhost:8080/healthz 2>/dev/null; then
+            if curl -sf http://localhost:8080/stores > /dev/null 2>&1; then
               echo "OpenFGA is ready"
               exit 0
             fi

--- a/.github/workflows/example-tests.yaml
+++ b/.github/workflows/example-tests.yaml
@@ -1,0 +1,37 @@
+name: Example Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  example-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      openfga:
+        image: openfga/openfga:latest
+        ports:
+          - 8080:8080
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8080/healthz || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 10s
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0'
+          bundler-cache: true
+
+      - name: Run example1
+        run: make run-example1
+        env:
+          FGA_LOCAL_API_URL: http://localhost:8080

--- a/example/example1/main.rb
+++ b/example/example1/main.rb
@@ -34,6 +34,7 @@ class OpenFgaExample
   end
 
   def run
+    raise "Intentional failure to test CI"
     @logger.info 'Starting OpenFGA Ruby SDK Example'
 
     # 0. Test connection first

--- a/example/example1/main.rb
+++ b/example/example1/main.rb
@@ -34,7 +34,6 @@ class OpenFgaExample
   end
 
   def run
-    raise "Intentional failure to test CI"
     @logger.info 'Starting OpenFGA Ruby SDK Example'
 
     # 0. Test connection first


### PR DESCRIPTION
## Summary

Runs example1 against a live OpenFGA server in CI so we know it actually works.

## What it does

- Starts `openfga/openfga:latest` with the `run` command in Docker
- Polls until the server is healthy
- Runs `make run-example1` (stores, auth models, tuples, checks, batch checks, expand, assertions)
- If the example exits non-zero, the workflow fails

## Notes

- Just example1 for now. Example2 needs an authenticated server, so I'll do that separately.
- Uses Ruby 4.0