### PR TITLE
fix: custom logger initialization and usage

### DIFF
--- a/example/example1/main.rb
+++ b/example/example1/main.rb
@@ -18,8 +18,8 @@ require 'ulid'
 # This example demonstrates how to use the OpenFGA Ruby SDK to interact with an OpenFGA server.
 class OpenFgaExample
   def initialize
-    @logger = Logger.new($stdout)
-    @logger.level = Logger::INFO
+    @logger = Logger.new(STDOUT)
+    @logger.level = Logger::DEBUG
 
     # Initialize the OpenFGA client
     # Replace with your OpenFGA server URL
@@ -105,7 +105,8 @@ class OpenFgaExample
       # Update client with store_id
       @client = OpenFga::SdkClient.new(
         api_url: ENV.fetch('FGA_API_URL', 'http://localhost:8080'),
-        store_id: @store_id
+        store_id: @store_id,
+        logger: @logger
       )
     end
 

--- a/example/example1/main.rb
+++ b/example/example1/main.rb
@@ -19,7 +19,7 @@ require 'ulid'
 class OpenFgaExample
   def initialize
     @logger = Logger.new(STDOUT)
-    @logger.level = Logger::DEBUG
+    @logger.level = Logger::INFO
 
     # Initialize the OpenFGA client
     # Replace with your OpenFGA server URL

--- a/lib/openfga/client/openfga_client.rb
+++ b/lib/openfga/client/openfga_client.rb
@@ -48,7 +48,7 @@ module OpenFga
         c.host = @config[:api_url]
         c.scheme = URI(@config[:api_url]).scheme
         c.logger = @logger
-        c.debugging = true # @config[:debug_logs] || false
+        c.debugging = true if @config[:logger]
       end
 
       @api_client = OpenFga::OpenFgaApi.new(ApiClient.new(api_client_config))

--- a/lib/openfga/client/openfga_client.rb
+++ b/lib/openfga/client/openfga_client.rb
@@ -17,7 +17,7 @@ module OpenFga
         method: :none
       }
 
-      @logger = config[:logger] || Logger.new($stdout)
+      @logger = config[:logger] || (defined?(Rails) ? Rails.logger : Logger.new($stdout))
 
       # Later we can support custom token managers.
       @token_manager = case @config[:credentials][:method]

--- a/lib/openfga/client/openfga_client.rb
+++ b/lib/openfga/client/openfga_client.rb
@@ -17,7 +17,8 @@ module OpenFga
         method: :none
       }
 
-      @logger = config[:logger] || (defined?(Rails) ? Rails.logger : Logger.new($stdout))
+      @logger = new_logger(@config)
+      @logger.debug('Using custom logger instance') if @config[:logger]
 
       # Later we can support custom token managers.
       @token_manager = case @config[:credentials][:method]
@@ -47,7 +48,7 @@ module OpenFga
         c.host = @config[:api_url]
         c.scheme = URI(@config[:api_url]).scheme
         c.logger = @logger
-        c.debugging = @config[:debug_logs] || false
+        c.debugging = true # @config[:debug_logs] || false
       end
 
       @api_client = OpenFga::OpenFgaApi.new(ApiClient.new(api_client_config))
@@ -580,6 +581,13 @@ module OpenFga
         {
           'Authorization' => "Bearer #{token}"
         }
+      end
+
+      def new_logger(config)
+        logger = Logger.new($stdout)
+        logger.level = Logger::INFO
+
+        config[:logger] || (defined?(Rails) ? Rails.logger : logger)
       end
   end
 end

--- a/lib/openfga/client/openfga_client.rb
+++ b/lib/openfga/client/openfga_client.rb
@@ -47,6 +47,7 @@ module OpenFga
         c.host = @config[:api_url]
         c.scheme = URI(@config[:api_url]).scheme
         c.logger = @logger
+        c.debugging = @config[:debug_logs] || false
       end
 
       @api_client = OpenFga::OpenFgaApi.new(ApiClient.new(api_client_config))

--- a/lib/openfga/token_manager/token_manager.rb
+++ b/lib/openfga/token_manager/token_manager.rb
@@ -55,7 +55,7 @@ module OpenFga
         @config = config
         @access_token_expires_at = nil
         @access_token = nil
-        @logger = config.logger || Logger.new($stdout)
+        @logger = config.logger || Logger.new(STDOUT)
       end
 
       def access_token
@@ -63,7 +63,7 @@ module OpenFga
           return @access_token
         end
 
-        @logger.info "Refreshing access token from #{@config.token_issuer}"
+        @logger.debug "Refreshing access token from #{@config.token_issuer}"
 
         form_data = {
           'grant_type' => 'client_credentials',
@@ -92,7 +92,7 @@ module OpenFga
           @access_token = body['access_token']
           @access_token_expires_at = Time.now.utc + body['expires_in'].to_i
 
-          @logger.info "Obtained new access token, expires at #{@access_token_expires_at}"
+          @logger.debug "Obtained new access token, expires at #{@access_token_expires_at}"
 
           @access_token
         else raise TokenRefreshError.new("Failed to obtain access token: #{response.code} #{response.body}")


### PR DESCRIPTION
The main changes here are:

- Fix `debugging: true` on the underlying client when a custom logger has been supplied. This forces it to always try to output debug logs but does allow the consumer of the SDK to control this through `Logger.level`. This defaults to `Level::INFO` when a custom logger has not been given.
- Added internal helper for building a logger
- Fixed the example, which was not outputting logs correctly