### PR TITLE
chore: empty rake task to fix publishing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,10 @@
 require 'bundler/gem_tasks'
 
+# release-please already pushes the tag and commit, so skip bundler's git push
+task 'release:source_control_push' do
+  # no-op
+end
+
 begin
   require 'rspec/core/rake_task'
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,8 @@
 require 'bundler/gem_tasks'
 
 # release-please already pushes the tag and commit, so skip bundler's git push
-task 'release:source_control_push' do
-  # no-op
-end
+Rake::Task['release:source_control_push'].clear
+task 'release:source_control_push' do; end
 
 begin
   require 'rspec/core/rake_task'


### PR DESCRIPTION
Example failed run: https://github.com/carlastabile/openfga-ruby-sdk/actions/runs/28229305330

The rake task looks to be getting in the way of checking out and tagging releases from `release-please`. Trying to republish by getting the fix into `main` and republishing as `0.3.1`.